### PR TITLE
Custom Tag Distribution

### DIFF
--- a/AntBot-GA/Simulation.h
+++ b/AntBot-GA/Simulation.h
@@ -55,12 +55,9 @@
 @property (nonatomic) int tickCount;
 @property (nonatomic) int clusteringTagCutoff;
 
-@property (nonatomic) float distributionRandom;
-@property (nonatomic) float distributionPowerlaw;
-@property (nonatomic) float distributionClustered;
-
 @property (nonatomic) int pileRadius;
-@property (nonatomic) int numberOfClusteredPiles;
+@property (nonatomic) int pileCount;
+@property (nonatomic) NSDictionary* tagDistribution;
 
 @property (nonatomic) float crossoverRate;
 @property (nonatomic) float mutationRate;


### PR DESCRIPTION
Starting a pull request for this.  Idea is to have an `NSDictionary` that specifies the tag distribution for the Simulation for easy interfacing with `.plist` files.  Format is:

```
@{
  @(64): @(1),
  @(32): @(2),
  @(1): @(128)
}
```

To create 1 pile of 64 tags, 2 piles of 32 tags, and 128 random tags.  The CLI should be able to do something similar to

```
NSString *tagDistributionFilePath = [NSString stringWithFormat:@"%@/tagDistribution.plist", theirDesktop];
if([[NSFileManager defaultManager] fileExistsAtPath:tagDistributionFilePath]) {
    [simulation setTagDistribution:[NSDictionary dictionaryWithContentsOfFile:tagDistributionFilePath]];
}
```

Alternatively, the short-hand method of specifying a number of evenly-sized clustered piles is still supported.  I renamed the property to `pileCount`.

Also, this is the first Simulation parameter that is an object, so it looks like there should probably be some sort of serialization/deserialization on the `tagDistribution` property when using `Archivable` methods.  Still looking at this.

Still want to work out `Archivable`, modify the CLI, and do some testing before merging.
